### PR TITLE
Makefile: flock on use of the cluster (#45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.knaut.claim
 /bin_*
 /firewall.lock
+/cluster.lock

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ go.DISABLE_GO_TEST = y
 go-test-nat: go-get
 	$(FLOCK) firewall.lock go test -v -exec sudo $(go.module)/internal/pkg/nat
 go-test-teleproxy: go-get test-cluster
-	$(FLOCK) firewall.lock go test -v -exec "sudo env PATH=${PATH} KUBECONFIG=${KUBECONFIG}" $(go.module)/cmd/teleproxy
-go-test-other: go-get
-	go test -v $(filter-out $(go.module)/internal/pkg/nat $(go.module)/cmd/teleproxy,$(go.pkgs))
+	$(FLOCK) firewall.lock $(FLOCK) cluster.lock go test -v -exec "sudo env PATH=${PATH} KUBECONFIG=${KUBECONFIG}" $(go.module)/cmd/teleproxy
+go-test-other: go-get test-cluster
+	$(FLOCK) cluster.lock go test -v $(filter-out $(go.module)/internal/pkg/nat $(go.module)/cmd/teleproxy,$(go.pkgs))
 .PHONY: go-test-nat go-test-teleproxy go-test-other
 go-test: go-test-nat go-test-teleproxy go-test-other
 
@@ -37,6 +37,7 @@ check: check-docker
 
 clean: release
 	$(FLOCK) firewall.lock rm firewall.lock
+	$(FLOCK) cluster.lock rm cluster.lock
 
 # Utility targets
 

--- a/build-aux/flock.mk
+++ b/build-aux/flock.mk
@@ -11,7 +11,7 @@ ifeq ($(words $(filter $(abspath $(lastword $(MAKEFILE_LIST))),$(abspath $(MAKEF
 ifneq ($(shell which flock &>/dev/null),)
 FLOCK = flock
 else
-FLOCK = GO111MODULE=off go run $(dir $(lastword $(MAKEFILE_LIST)))/flock.go
+FLOCK = env GO111MODULE=off go run $(dir $(lastword $(MAKEFILE_LIST)))/flock.go
 endif
 
 endif


### PR DESCRIPTION
Apparently `go-test-other` accesses the cluster.  And it can fight with `go-test-teleproxy`.

So add a `cluster.lock` file so that only one of those targets can access the cluster at a time.

I believe this fixes https://github.com/datawire/teleproxy/issues/45  Before merging, I would like that believe to be verified by someone more familiar with the implementation.