### PR TITLE
build-aux improvements (help.mk, flock.mk)

### DIFF
--- a/build-aux/_go-common.mk
+++ b/build-aux/_go-common.mk
@@ -44,7 +44,7 @@ go.bins := $(call go.list,-f='{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./..
 # Rules
 
 # go-FOO.mk is responsible for implementing go-get
-go-get: ## Download Go dependencies
+go-get: ## (Go) Download Go dependencies
 .PHONY: go-get
 
 define _go.bin.rule
@@ -56,21 +56,21 @@ $(foreach go.bin,$(go.bins),$(eval $(_go.bin.rule)))
 go-build: $(addprefix bin_$(GOOS)_$(GOARCH)/,$(notdir $(go.bins)))
 .PHONY: go-build
 
-check-go-fmt: ## Check whether the code conforms to `gofmt`
+check-go-fmt: ## (Go) Check whether the code conforms to `gofmt`
 	test -z "$$(git ls-files '*.go' | grep -v -e ^vendor/ -e /vendor/ | xargs gofmt -d | tee /dev/stderr)"
 .PHONY: check-go-fmt
 
-go-vet: ## Check the code with `go vet`
+go-vet: ## (Go) Check the code with `go vet`
 go-vet: go-get
 	go vet $(go.pkgs)
 .PHONY: go-vet
 
-go-fmt: ## Fixup the code with `go fmt`
+go-fmt: ## (Go) Fixup the code with `go fmt`
 go-fmt: go-get
 	go fmt ./...
 .PHONY: go-fmt
 
-go-test: ## Check the code with `go test`
+go-test: ## (Go) Check the code with `go test`
 go-test: go-get
 	$(if $(not $(go.DISABLE_GO_TEST)),go test $(go.pkgs))
 .PHONY: go-test

--- a/build-aux/flock
+++ b/build-aux/flock
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Copyright 2018 Datawire. All rights reserved.
+#
+# Wrapper around `go run ./flock.go` to set GO111MODULe appropriately.
+
+lockfile=$1
+shift
+GO111MODULE=off go run "$0.go" "$lockfile" env GO111MODULE="${GO111MODULE}" "$@"

--- a/build-aux/flock.mk
+++ b/build-aux/flock.mk
@@ -8,7 +8,7 @@
 #  - Variable: FLOCK
 ifeq ($(words $(filter $(abspath $(lastword $(MAKEFILE_LIST))),$(abspath $(MAKEFILE_LIST)))),1)
 
-ifneq ($(shell which flock &>/dev/null),)
+ifneq ($(shell which flock 2>/dev/null),)
 FLOCK = flock
 else
 FLOCK := $(dir $(lastword $(MAKEFILE_LIST)))flock

--- a/build-aux/flock.mk
+++ b/build-aux/flock.mk
@@ -11,7 +11,7 @@ ifeq ($(words $(filter $(abspath $(lastword $(MAKEFILE_LIST))),$(abspath $(MAKEF
 ifneq ($(shell which flock &>/dev/null),)
 FLOCK = flock
 else
-FLOCK := env GO111MODULE=off go run $(dir $(lastword $(MAKEFILE_LIST)))flock.go
+FLOCK := $(dir $(lastword $(MAKEFILE_LIST)))flock
 endif
 
 endif

--- a/build-aux/help.mk
+++ b/build-aux/help.mk
@@ -55,7 +55,7 @@ help:  ## Show this message
 	@printf '%s\n' $(call quote.shell,$(help.body)) | sed -e 's/^# //' -e 's/^#//'
 	@echo
 	@echo TARGETS:
-	@sed -En 's/^([^#]*) *: *[#]# */\1	/p' ${MAKEFILE_LIST} | column -t -s '	' | sed 's/^/  /'
+	@sed -En 's/^([^#]*) *: *[#]# */\1	/p' $(sort $(abspath $(MAKEFILE_LIST))) | column -t -s '	' | sed 's/^/  /'
 .PHONY: help
 
 endif

--- a/build-aux/help.mk
+++ b/build-aux/help.mk
@@ -19,9 +19,15 @@
 #             recipe
 #     .PHONY: my-rule
 #
+#     my-other-rule: ## (Category) A description of my-other-rule
+#     my-other-rule: dep1 dep2
+#             recipe
+#     .PHONY: my-other-rule
+#
 # The double "##" is important.  It is also important that there be no
 # dependencies between the ":" and the "##"; any ammount of whitespace
-# is acceptable, though.
+# is acceptable, though.  The "##" may optionally be followed by a
+# category in parenthesis.
 #
 ## Advanced example ##
 #
@@ -55,7 +61,7 @@ help:  ## Show this message
 	@printf '%s\n' $(call quote.shell,$(help.body)) | sed -e 's/^# //' -e 's/^#//'
 	@echo
 	@echo TARGETS:
-	@sed -En 's/^([^#]*) *: *[#]# */\1	/p' $(sort $(abspath $(MAKEFILE_LIST))) | column -t -s '	' | sed 's/^/  /'
+	@sed -En 's/^([^#]*) *: *[#]# *(\([^)]*\))? */\2	\1	/p' $(sort $(abspath $(MAKEFILE_LIST))) | sort | column -t -s '	' | sed 's/^/  /'
 .PHONY: help
 
 endif

--- a/build-aux/kubernaut-ui.mk
+++ b/build-aux/kubernaut-ui.mk
@@ -17,15 +17,15 @@ include $(dir $(lastword $(MAKEFILE_LIST)))kubernaut.mk
 _KUBECONFIG := $(or $(NAME),cluster).knaut
 export KUBECONFIG = $(_KUBECONFIG)
 
-claim: ## Obtain an ephemeral k8s cluster from kubernaut.io
+claim: ## (Kubernaut) Obtain an ephemeral k8s cluster from kubernaut.io
 claim: $(KUBECONFIG)
 .PHONY: claim
 
-release: ## Release the cluster claimed by 'claim'
+release: ## (Kubernaut) Release the cluster claimed by 'claim'
 release: $(_KUBECONFIG).clean
 .PHONY: release
 
-shell: ## Run an interactive Bash shell with KUBECONFIG= set to a Kubernaut claim
+shell: ## (Kubernaut) Run an interactive Bash shell with KUBECONFIG= set to a Kubernaut claim
 shell: $(KUBECONFIG)
 	@exec env -u MAKELEVEL PS1="(dev) [\W]$$ " bash
 .PHONY: shell


### PR DESCRIPTION
These are some build-aux improvements factored out of the go-mod PR, and work built on that (that you can see in the `lukeshu/wip` branch).

 - `help.mk`: Don't list duplicate targets
 - `help.mk`: Add the ability to put targets in to categories
 - `flock.mk`: Use native flock if available
 - `flock.mk`: Work properly with Go modules
 - `_go-common.mk`, `kubernaut-ui.mk`: Improve `##` comments for `make help` output