### PR TITLE
Update build-aux, have no symlinks

### DIFF
--- a/build-aux/README.md
+++ b/build-aux/README.md
@@ -33,9 +33,6 @@ Currently, there are 2 options for Go projects:
  - `go-workspace.mk`: For GOPATH workspaces
  - `go-mod.mk`: For Go 1.11 modules
 
-`go.mk` is a symlink that currently points to `go-workspace.mk`, but
-at some point in the future it will change to point to `go-mod.mk`
-
 ### Initializing a `go-workspace.mk` project
 
 	$ MODULE=EXAMPLE.COM/YOU/GITREPO
@@ -65,5 +62,5 @@ understand the `-r` flag.
 
 	$ make clobber
 	$ rm -rf -- .go-workspace vendor glide.* Gopkg.*
-	$ sed -E 's,/go(-workspace)?\.mk,/go-mod.mk,' Makefile
+	$ sed -E 's,/go-workspace\.mk,/go-mod.mk,' Makefile
 	$ sed -e '/\.go-workspace/d' .gitignore

--- a/build-aux/go-mod.mk
+++ b/build-aux/go-mod.mk
@@ -61,6 +61,10 @@ ifneq ($(words $(go.module)),1)
   $(error Could not extract $$(go.module) from ./go.mod)
 endif
 
+ifneq ($(shell git ls-tree -rl HEAD | grep '^120000 ' | tee /dev/stderr),)
+$(error You may not use symlinks with Go modules)
+endif
+
 #
 # 2. Set go.pkgs
 

--- a/build-aux/go.mk
+++ b/build-aux/go.mk
@@ -1,1 +1,0 @@
-go-workspace.mk

--- a/build-aux/k8s.mk
+++ b/build-aux/k8s.mk
@@ -35,12 +35,12 @@ _build-k8s:
 endif
 clean: $(addsuffix .docker.clean,$(K8S_IMAGES))
 
-push: ## (k8s) Push Docker images to kubernaut.io cluster
+push: ## (Kubernaut) Push Docker images to kubernaut.io cluster
 push: $(addsuffix .docker.knaut-push,$(K8S_IMAGES))
 .PHONY: push
 
-apply:  ## (k8s) Apply YAML to kubernaut.io cluster, without pushing newer Docker images the (this is useful for quickly deploying YAML-only changes)
-deploy: ## (k8s) Apply YAML to kubernaut.io cluster, pushing newer Docker images
+apply:  ## (Kubernaut) Apply YAML to kubernaut.io cluster, without pushing newer Docker images (this is useful for quickly deploying YAML-only changes)
+deploy: ## (Kubernaut) Apply YAML to kubernaut.io cluster, pushing newer Docker images
 _k8s.push = $(addsuffix .docker.knaut-push,$(K8S_IMAGES))
 apply: $(filter-out $(wildcard $(_k8s.push)),$(_k8s.push))
 deploy: $(_k8s.push)


### PR DESCRIPTION
The `./build-aux/go.mk` symlink confused certain versions of Go, and caused disagreements about hashes.