### PR TITLE
Fix go not caching linker results, breaking release on macOS

### DIFF
--- a/build-aux/_go-common.mk
+++ b/build-aux/_go-common.mk
@@ -48,16 +48,14 @@ go-get: ## (Go) Download Go dependencies
 .PHONY: go-get
 
 define _go.bin.rule
-bin_%/.tmp.$(notdir $(go.bin)).tmp: go-get FORCE
+bin_%/.cache.$(notdir $(go.bin)): go-get FORCE
 	go build $$(if $$(go.LDFLAGS),--ldflags $$(call quote.shell,$$(go.LDFLAGS))) -o $$@ $(go.bin)
-bin_%/$(notdir $(go.bin)): bin_%/.tmp.$(notdir $(go.bin)).tmp
+bin_%/$(notdir $(go.bin)): bin_%/.cache.$(notdir $(go.bin))
 	@{ \
 		PS4=''; set -x; \
-		if cmp -s $$< $$@; then \
-			rm -f $$< || true; \
-		else \
+		if ! cmp -s $$< $$@; then \
 			$(if $(CI),if test -e $$@; then false This should not happen in CI: $$@ should not change; fi, true) && \
-			mv -f $$< $$@; \
+			cp -f $$< $$@; \
 		fi; \
 	}
 endef

--- a/build-aux/_go-common.mk
+++ b/build-aux/_go-common.mk
@@ -51,7 +51,15 @@ define _go.bin.rule
 bin_%/.tmp.$(notdir $(go.bin)).tmp: go-get FORCE
 	go build $$(if $$(go.LDFLAGS),--ldflags $$(call quote.shell,$$(go.LDFLAGS))) -o $$@ $(go.bin)
 bin_%/$(notdir $(go.bin)): bin_%/.tmp.$(notdir $(go.bin)).tmp
-	if cmp -s $$< $$@; then rm -f $$< || true; else $(if $(CI),test ! -e $$@ && )mv -f $$< $$@; fi
+	@{ \
+		PS4=''; set -x; \
+		if cmp -s $$< $$@; then \
+			rm -f $$< || true; \
+		else \
+			$(if $(CI),if test -e $$@; then false This should not happen in CI: $$@ should not change; fi, true) && \
+			mv -f $$< $$@; \
+		fi; \
+	}
 endef
 $(foreach go.bin,$(go.bins),$(eval $(_go.bin.rule)))
 


### PR DESCRIPTION
Problem:
 - The macOS build of teleproxy uses github.com/datawire/pf
 - github.com/datawire/pf uses cgo
 - If cgo is used, the `go` compiler won't cache linker results in `$(go env GOCACHE)`, but it will possibly use the output binary as a cache.
 - If the linker results aren't cached, it will re-run the linker
 - If it needs to re-run the linker, it will use a different tmpdir
 - The tmpdir will make it in to the binary
 - This will cause the binary to change *during* `make release`
 - The Makefile will correctly detect that the binary is changing during `make release` and trigger an error
 - This results in https://circleci.com/gh/datawire/teleproxy/587

The fact that most builds don't use cgo is the reason why this hasn't been caught yet.

Fix:
 - Store a persistent `bin_*/.cache.NAME` file that the `go` compiler can use as a cache
 - Have a better error message so that someone other than me has a chance of being able to debug this type of issue
