### PR TITLE
Ignore endpoint updates from kube-system

### DIFF
--- a/cmd/kubewatch/kubewatch.go
+++ b/cmd/kubewatch/kubewatch.go
@@ -117,12 +117,15 @@ func (s *Syncer) Run() {
 		// value from the current iteration instead of the
 		// value from the last iteration
 		kind := k
-		s.Watcher.WatchNamespace(NAMESPACE, kind, func(_ *k8s.Watcher) {
+		err := s.Watcher.WatchNamespace(NAMESPACE, kind, func(_ *k8s.Watcher) {
 			s.Mux.Lock()
 			defer s.Mux.Unlock()
 			s.Dirty = true
 			s.ModTime = time.Now()
 		})
+		if err != nil {
+			log.Fatalf("kubewatch: %v", err)
+		}
 	}
 	s.Watcher.Start()
 	s.serve()

--- a/go.mod
+++ b/go.mod
@@ -40,9 +40,11 @@ require (
 	google.golang.org/genproto v0.0.0-20190123001331-8819c946db44 // indirect
 	google.golang.org/grpc v1.18.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
-	k8s.io/api v0.0.0-20181221193117-173ce66c1e39 // indirect
 	k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee
-	k8s.io/client-go v10.0.0+incompatible
 	k8s.io/klog v0.1.0 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
+	// We need to pin k8s.io/api and k8s.io/client-go to their respective releases
+	// because api has been removed from master
+	k8s.io/api kubernetes-1.13.2
+	k8s.io/client-go v10.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -40,11 +40,11 @@ require (
 	google.golang.org/genproto v0.0.0-20190123001331-8819c946db44 // indirect
 	google.golang.org/grpc v1.18.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
-	k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee
-	k8s.io/klog v0.1.0 // indirect
-	sigs.k8s.io/yaml v1.1.0 // indirect
 	// We need to pin k8s.io/api and k8s.io/client-go to their respective releases
 	// because api has been removed from master
-	k8s.io/api kubernetes-1.13.2
-	k8s.io/client-go v10.0.0
+	k8s.io/api v0.0.0-20190111032252-67edc246be36 // indirect
+	k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee
+	k8s.io/client-go v10.0.0+incompatible
+	k8s.io/klog v0.1.0 // indirect
+	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -256,8 +256,8 @@ grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJd
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-k8s.io/api v0.0.0-20181221193117-173ce66c1e39 h1:iGq7zEPXFb0IeXAQK5RiYT1SVKX/af9F9Wv0M+yudPY=
-k8s.io/api v0.0.0-20181221193117-173ce66c1e39/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
+k8s.io/api v0.0.0-20190111032252-67edc246be36 h1:XrFGq/4TDgOxYOxtNROTyp2ASjHjBIITdk/+aJD+zyY=
+k8s.io/api v0.0.0-20190111032252-67edc246be36/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee h1:3MH/wGFP+9PjyLIMnPN2GYatdJosd+5TnSO2BzQqqo4=
 k8s.io/apimachinery v0.0.0-20190119020841-d41becfba9ee/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/client-go v10.0.0+incompatible h1:F1IqCqw7oMBzDkqlcBymRq1450wD0eNqLE9jzUrIi34=


### PR DESCRIPTION
    kube-scheduler and kube-controller-manager endpoints are
    updated almost every second, leading to terrible noise,
    and hence constant listener invokation. So, here we
    ignore endpoint updates from kube-system namespace. More:
    https://github.com/kubernetes/kubernetes/issues/41635
    https://github.com/kubernetes/kubernetes/issues/34627
