### PR TITLE
Makefile: Adjust to work with build-aux's new TAP-based `make check`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,14 @@ commands:
           command: make unclaim
           when: always
       - run: make build
+      - run:
+          name: "gather logs"
+          when: always
+          command: |
+            rsync -ma --include='*/' --include='*.tap' --include='*.log' --exclude='*' . /tmp/test-logs
+      - store_artifacts:
+          path: /tmp/test-logs
+          destination: test-logs
       - run: |
           if test -n "$CIRCLE_TAG"; then
               export AWS_ACCESS_KEY_ID=$DEPLOY_KEY_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
   macos-build:
     macos:
       xcode: "9.0"
-    working_directory: ~/go/src/github.com/datawire/teleproxy
+    working_directory: ~/repo
     steps:
       - aws-install
       - golang-install:
@@ -73,7 +73,7 @@ jobs:
 
   machine-build:
     machine: true
-    working_directory: ~/go/src/github.com/datawire/teleproxy
+    working_directory: ~/repo
     steps:
       - aws-install
       - golang-install:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.docker
 *.knaut
 *.knaut.claim
+*.tap
 /bin_*
 /.firewall.lock
 /.cluster.lock

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+# We need to pass special `-exec …` flags to to `go test` for certain
+# packages, so disable go-mod.mk's built-in go-test, and we'll define
+# our own below
+go.DISABLE_GO_TEST = y
+
 include build-aux/common.mk
 include build-aux/go-mod.mk
 include build-aux/go-version.mk
@@ -13,23 +18,20 @@ test-cluster: $(KUBECONFIG) bin_$(GOOS)_$(GOARCH)/kubeapply
 	bin_$(GOOS)_$(GOARCH)/kubeapply -f k8s
 .PHONY: test-cluster
 
-# We need to pass special `-exec …` flags to to `go test` for certain
-# packages, so disable go.mk's built-in go-test, and define our own.
-go.DISABLE_GO_TEST = y
-go-test-nat: go-get
-	$(FLOCK) .firewall.lock go test -v -exec sudo $(go.module)/internal/pkg/nat
-go-test-teleproxy: go-get test-cluster
-	$(FLOCK) .firewall.lock $(FLOCK) .cluster.lock go test -v -exec "sudo env KUBECONFIG=$${KUBECONFIG}" $(go.module)/cmd/teleproxy
-go-test-other: go-get test-cluster
-	$(FLOCK) .cluster.lock go test -v $$(go list ./... | grep -vF -e $(go.module)/internal/pkg/nat -e $(go.module)/cmd/teleproxy)
-.PHONY: go-test-nat go-test-teleproxy go-test-other
-go-test: go-test-nat go-test-teleproxy go-test-other
+test-suite.tap: .go-test.tap
+check: test-cluster
+go-test: test-cluster
+	$(MAKE) .go-test.tap.summary
+.go-test.tap: .go-test-nat.tap .go-test-teleproxy.tap .go-test-other.tap
+	@./build-aux/tap-driver cat $^ > $@
+# .tap-file                    [----firewall.lock----] [----cluster.lock----]               [---------------extra flags--------------] [----------------------------------------packages-----------------------------------------]
+.go-test-nat.tap      : FORCE; @$(FLOCK) .firewall.lock                        go test -json -exec sudo                                 $(go.module)/internal/pkg/nat                                                               | GO111MODULE=off go run build-aux/gotest2tap.go | tee $@ | build-aux/tap-driver stream -n $@
+.go-test-teleproxy.tap: FORCE; @$(FLOCK) .firewall.lock $(FLOCK) .cluster.lock go test -json -exec "sudo env KUBECONFIG=$${KUBECONFIG}" $(go.module)/cmd/teleproxy                                                                  | GO111MODULE=off go run build-aux/gotest2tap.go | tee $@ | build-aux/tap-driver stream -n $@
+.go-test-other.tap    : FORCE; @                        $(FLOCK) .cluster.lock go test -json                                            $$(go list ./... | grep -vF -e $(go.module)/internal/pkg/nat -e $(go.module)/cmd/teleproxy) | GO111MODULE=off go run build-aux/gotest2tap.go | tee $@ | build-aux/tap-driver stream -n $@
 
-check-docker:
 ifneq ($(shell which docker 2>/dev/null),)
-check-docker: docker/teleproxy-check.docker
-check-docker:
-	$(if $(filter linux,$(GOOS)),$(FLOCK) .firewall.lock) docker run --rm --cap-add=NET_ADMIN $(docker.LOCALHOST):31000/teleproxy-check:$(VERSION) go-test-nat
+.docker.tap: docker/teleproxy-check.docker
+	@$(if $(filter linux,$(GOOS)),$(FLOCK) .firewall.lock) docker run --rm --cap-add=NET_ADMIN "$$(sed -n 3p $<)" go test -json -exec sudo $(go.module)/internal/pkg/nat | GO111MODULE=off go run build-aux/gotest2tap.go | tee $@ | build-aux/tap-driver stream -n $@
 docker/teleproxy-check.docker: docker/teleproxy-check/teleproxy.tar
 docker/teleproxy-check/teleproxy.tar: go-get
 	rm -f $@
@@ -43,14 +45,15 @@ docker/teleproxy-check/teleproxy.tar: go-get
 	tar -c -f $@ -C $(@D)/.tmp/teleproxy .
 	rm -rf $(@D)/.tmp
 else
-	@echo "SKIPPING DOCKER TESTS"
+.docker.tap: .go-test-nat.tap
+	@sed -En -e '/^TAP version/p' -e 's/^(not )?ok([^#]*)(#.*)?/ok\2 # SKIP/p' -e '/^[0-9]+\.\.[0-9]+$$/p' $< | tee $@ | build-aux/tap-driver stream -n $@
 endif
-.PHONY: check-docker
-check: check-docker
+test-suite.tap: .docker.tap
 
 clean:
 	$(FLOCK) .firewall.lock rm .firewall.lock
 	$(FLOCK) .cluster.lock rm .cluster.lock
+	rm -f -- .*.tap
 
 # Utility targets
 

--- a/build-aux/gotest2tap.go
+++ b/build-aux/gotest2tap.go
@@ -66,13 +66,13 @@ func main() {
 			case "fail":
 				testCnt++
 				pkgTestCnt[event.Package] = pkgTestCnt[event.Package] + 1
-				fmt.Printf("not ok %d %v.%v # %v (%v) %v\n", testCnt, Name, Time, Elapsed, Output)
+				fmt.Printf("not ok %d %v # %v (%v) %v\n", testCnt, Name, Time, Elapsed, Output)
 			case "skip":
 				testCnt++
 				pkgTestCnt[event.Package] = pkgTestCnt[event.Package] + 1
-				fmt.Printf("ok %d %v.%v # SKIP %v (%v) %v\n", testCnt, Name, Time, Elapsed, Output)
+				fmt.Printf("ok %d %v # SKIP %v (%v) %v\n", testCnt, Name, Time, Elapsed, Output)
 			default:
-				fmt.Sprintln("#",
+				fmt.Println("#",
 					Time,
 					"(took "+Elapsed.String()+")",
 					fmt.Sprintf("%-6s", event.Action),

--- a/docker/teleproxy-check/Dockerfile
+++ b/docker/teleproxy-check/Dockerfile
@@ -6,4 +6,3 @@ ADD teleproxy.tar .
 
 ENV CGO_ENABLED=0
 ENV GOFLAGS=-mod=vendor
-ENTRYPOINT [ "make" ]


### PR DESCRIPTION
- go.DISABLE_GO_TEST must be set *before* including go-mod.mk in order to affect `make go-test` (it affects `make check` either way)
 - the Makefile was written for the old free-form BYO-test-harness build-aux `make check`; adjust it to work with the new TAP-based test-harness. (I forgot to include `check: test-cluster` in an earlier version of this PR)
 - fix bugs in gotest2tap causing mangled output
 - fix embarrassing bug in gotest2tap causing diagnostic lines to not be included in the `.tap` log (s/Sprintln/Println/)
 - Save test logs as build artifacts, to make debugging CI possible