### PR TITLE
initial draft of supervisor package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b // indirect
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
 	golang.org/x/oauth2 v0.0.0-20190115181402-5dab4167f31c // indirect
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
 	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e // indirect
 	google.golang.org/genproto v0.0.0-20190123001331-8819c946db44 // indirect
 	google.golang.org/grpc v1.18.0 // indirect

--- a/pkg/supervisor/examples_test.go
+++ b/pkg/supervisor/examples_test.go
@@ -1,0 +1,111 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+)
+
+func Example() {
+	// We are going to create a server and a client worker. The
+	// server needs to first bind to a port before it is ready to
+	// use. By listing the dependency between the client and the
+	// server worker, the client will not be started until the
+	// server signals that it is ready.
+	ctx := context.Background()
+	s := WithContext(ctx)
+	var addr string
+	s.Supervise(&Worker{
+		Name: "server",
+		Work: func(p *Process) error {
+			// :0 will ask for an unused port
+			l, err := net.Listen("tcp", ":0")
+			if err != nil {
+				return err
+			}
+			defer l.Close()
+			// store the unused port that was allocated so
+			// that the client knows where to talk to
+			addr = l.Addr().String()
+			p.Logf("listening on %s", addr)
+
+			http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("hello"))
+				s.Shutdown()
+			})
+
+			srv := &http.Server{}
+			// launch an anonymous child worker to serve requests
+			p.Go(func(p *Process) error {
+				return srv.Serve(l)
+			})
+
+			fmt.Println("server ready")
+			// signal that we are ready
+			p.Ready()
+
+			select {
+			case <-p.Shutdown(): // await graceful shutdown signal
+				return srv.Shutdown(p.Context)
+			case <-p.Context.Done(): // await hard shutdown signal
+				return srv.Shutdown(p.Context)
+			}
+		},
+	})
+	s.Supervise(&Worker{
+		Name:     "client",
+		Requires: []string{"server"},
+		Work: func(p *Process) error {
+			resp, err := http.Get(fmt.Sprintf("http://%s", addr))
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			bytes, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("client %s\n", string(bytes))
+			return nil
+		},
+	})
+	errors := s.Run()
+	for _, err := range errors {
+		log.Println(err.Error())
+	}
+	// Output: server ready
+	// client hello
+}
+
+func ExampleSupervisor() {
+	ctx := context.Background()
+	s := WithContext(ctx)
+	for idx, url := range []string{"https://www.google.com", "https://www.bing.com"} {
+		url_capture := url
+		s.Supervise(&Worker{
+			Name: fmt.Sprintf("url-%d", idx),
+			Work: func(p *Process) error {
+				resp, err := http.Get(url)
+				if err != nil {
+					return err
+				}
+				defer resp.Body.Close()
+				fmt.Printf("url %s: %s\n", url_capture, resp.Status)
+				return nil
+			},
+		})
+	}
+
+	// The Run() method will block until all workers are done. Any
+	// and all background errors in workers, including panics are
+	// returned by Run().
+	errors := s.Run()
+	for _, err := range errors {
+		fmt.Println(err)
+	}
+	// Unordered output: url https://www.bing.com: 200 OK
+	// url https://www.google.com: 200 OK
+}

--- a/pkg/supervisor/examples_test.go
+++ b/pkg/supervisor/examples_test.go
@@ -47,12 +47,8 @@ func Example() {
 			// signal that we are ready
 			p.Ready()
 
-			select {
-			case <-p.Shutdown(): // await graceful shutdown signal
-				return srv.Shutdown(p.Context)
-			case <-p.Context.Done(): // await hard shutdown signal
-				return srv.Shutdown(p.Context)
-			}
+			<-p.Shutdown() // await graceful shutdown signal
+			return srv.Shutdown(p.Context())
 		},
 	})
 	s.Supervise(&Worker{

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -178,7 +178,12 @@ OUTER:
 		w := s.workers[n]
 		if w.process == nil {
 			for _, r := range w.Requires {
-				process := s.workers[r].process
+				required := s.workers[r]
+				if required == nil {
+					log.Printf("cannot start %s, required worker missing: %s", n, r)
+					continue OUTER
+				}
+				process := required.process
 				if process == nil || !process.ready {
 					log.Printf("cannot start %s, %s not ready", n, r)
 					continue OUTER

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -64,6 +64,7 @@ func (s *Supervisor) Supervise(worker *Worker) {
 	s.names = append(s.names, worker.Name)
 }
 
+// this assumes that s.mutex is already held
 func (s *Supervisor) remove(worker *Worker) {
 	delete(s.workers, worker.Name)
 	var newNames []string

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -102,12 +102,11 @@ func (s *Supervisor) remove(worker *Worker) {
 func (s *Supervisor) Run() []error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+	// reconcile may delete workers
+	s.reconcile()
 	for len(s.workers) > 0 {
+		s.changed.Wait()
 		s.reconcile()
-		// reconcile may delete workers
-		if len(s.workers) > 0 {
-			s.changed.Wait()
-		}
 	}
 	return s.errors
 }

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -283,5 +283,4 @@ func (p *Process) Go(fn func(*Process) error) {
 		Name: fmt.Sprintf("%s[%d]", p.Worker().Name, id),
 		Work: fn,
 	})
-	return
 }

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -1,0 +1,237 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+)
+
+// A supervisor provides an abstraction for managing a group of
+// related goroutines, and provides:
+//
+// - startup and shutdown ordering based on dependencies
+// - both graceful and hard shutdown
+// - error propagation
+// - retry
+// - logging
+//
+type Supervisor struct {
+	mutex        *sync.Mutex
+	changed      *sync.Cond // used to signal when a worker is ready or done
+	context      context.Context
+	shuttingDown bool               // signals we are in shutdown mode
+	names        []string           // list of worker names in order added
+	workers      map[string]*Worker // keyed by worker name
+	errors       []error
+}
+
+func WithContext(ctx context.Context) *Supervisor {
+	mu := &sync.Mutex{}
+	return &Supervisor{
+		mutex:   mu,
+		changed: sync.NewCond(mu),
+		context: ctx,
+		workers: make(map[string]*Worker),
+	}
+}
+
+type Worker struct {
+	Name     string               // the name of the worker
+	Work     func(*Process) error // the function to perform the work
+	Requires []string             // a list of required worker names
+	Retry    bool                 // whether or not to retry on error
+	process  *Process             // nil if the worker is not currently running
+}
+
+func (s *Supervisor) Supervise(worker *Worker) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	_, exists := s.workers[worker.Name]
+	if exists {
+		panic(fmt.Sprintf("worker already exists: %s", worker.Name))
+	}
+	s.workers[worker.Name] = worker
+	s.names = append(s.names, worker.Name)
+}
+
+func (s *Supervisor) remove(worker *Worker) {
+	delete(s.workers, worker.Name)
+	var newNames []string
+	for _, name := range s.names {
+		if name == worker.Name {
+			continue
+		} else {
+			newNames = append(newNames, name)
+		}
+	}
+	s.names = newNames
+}
+
+// A supervisor will run until all its workers exit. There are
+// multiple ways workers can exit:
+//
+//   - normally (returning a non-nil error)
+//   - error (either via return result or panic)
+//   - graceful shutdown request
+//   - canceled context
+//
+// A normal exit does not trigger any special action other than
+// causing Run to return if it is the last worker.
+//
+// If a worker exits with an error, the behavior depends on the value
+// of the Retry flag on the worker. If Retry is true, the worker will
+// be restarted. If not the supervisor shutdown sequence is triggerd.
+//
+// The supervisor shutdown sequence can be deliberately triggered by
+// invoking supervisor.Shutdown(). This can be done from any goroutine
+// including workers.
+//
+// The graceful shutdown sequence shuts down workers in an order that
+// respects worker dependencies.
+func (s *Supervisor) Run() []error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	for len(s.workers) > 0 {
+		s.reconcile()
+		s.changed.Wait()
+	}
+	return s.errors
+}
+
+// Triggers a graceful shutdown sequence. This can be invoked from any
+// goroutine.
+func (s *Supervisor) Shutdown() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.shuttingDown = true
+	s.changed.Broadcast()
+}
+
+func (s *Supervisor) dependents(worker *Worker) (result []*Worker) {
+	for _, n := range s.names {
+		w := s.workers[n]
+		for _, r := range w.Requires {
+			if r == worker.Name {
+				result = append(result, w)
+				break
+			}
+		}
+	}
+	return
+}
+
+// make sure anything that would like to be running is actually
+// running
+func (s *Supervisor) reconcile() {
+	if s.shuttingDown {
+		s.reconcileShutdown()
+	} else {
+		s.reconcileNormal()
+	}
+}
+
+// shutdown anything that is safe to shutdown and not already shutdown
+func (s *Supervisor) reconcileShutdown() {
+OUTER:
+	for _, n := range s.names {
+		w := s.workers[n]
+		if w.process != nil && !w.process.shutdownClosed {
+			for _, d := range s.dependents(w) {
+				if s.workers[d.Name].process != nil {
+					log.Printf("cannot shutdown %s, %s still running", n, d.Name)
+					continue OUTER
+				}
+			}
+			close(w.process.shutdown)
+			w.process.shutdownClosed = true
+		}
+	}
+}
+
+// launch anything that is safe to launch and not already launched
+func (s *Supervisor) reconcileNormal() {
+OUTER:
+	for _, n := range s.names {
+		w := s.workers[n]
+		if w.process == nil {
+			for _, r := range w.Requires {
+				process := s.workers[r].process
+				if process == nil || !process.ready {
+					log.Printf("cannot start %s, %s not ready", n, r)
+					continue OUTER
+				}
+			}
+			s.launch(w)
+		}
+	}
+}
+
+func (s *Supervisor) launch(worker *Worker) {
+	context, cancel := context.WithCancel(s.context)
+	process := &Process{
+		Supervisor: s,
+		Worker:     worker,
+		Context:    context,
+		cancel:     cancel,
+		shutdown:   make(chan struct{}),
+	}
+	worker.process = process
+	go func() {
+		err := worker.Work(process)
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+		worker.process = nil
+		if err != nil {
+			process.Log(err)
+			if worker.Retry {
+				if s.shuttingDown {
+					s.remove(worker)
+				} else {
+					process.Log("retrying...")
+				}
+			} else {
+				s.remove(worker)
+				s.errors = append(s.errors, err)
+				s.shuttingDown = true
+			}
+		} else {
+			s.remove(worker)
+		}
+		s.changed.Broadcast()
+	}()
+}
+
+type Process struct {
+	Supervisor *Supervisor
+	Worker     *Worker
+	ready      bool
+	// Used for hard cancel.
+	Context context.Context
+	cancel  context.CancelFunc
+	// Used to signal graceful shutdown.
+	shutdown       chan struct{}
+	shutdownClosed bool
+}
+
+// Invoked by a worker to signal it is ready.
+func (p *Process) Ready() {
+	p.Supervisor.mutex.Lock()
+	defer p.Supervisor.mutex.Unlock()
+	p.ready = true
+	p.Supervisor.changed.Broadcast()
+}
+
+// Used for graceful shutdown...
+func (p *Process) Shutdown() <-chan struct{} {
+	return p.shutdown
+}
+
+// Used for logging...
+func (p *Process) Log(obj interface{}) {
+	log.Printf("%s: %v", p.Worker.Name, obj)
+}
+
+func (p *Process) Logf(format string, args ...interface{}) {
+	log.Printf("%s: %v", p.Worker.Name, fmt.Sprintf(format, args...))
+}

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -445,7 +445,9 @@ func TestGoPanic(t *testing.T) {
 		OnReady: func(spec *Spec) {
 			spec.process.Go(func(p *Process) error {
 				went = true
-				panic("boo")
+				if true {
+					panic("boo")
+				}
 				return nil
 			})
 		},

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -220,7 +220,7 @@ func TestDependency(t *testing.T) {
 			if r["minion"].state != READY {
 				panic("minion not ready")
 			}
-			spec.process.Supervisor.Shutdown()
+			spec.process.Supervisor().Shutdown()
 		},
 	}))
 	errors := s.Run()
@@ -296,7 +296,7 @@ func TestShutdown(t *testing.T) {
 	s.Supervise(r.worker(Spec{
 		Name: "quitter",
 		OnReady: func(spec *Spec) {
-			spec.process.Supervisor.Shutdown()
+			spec.process.Supervisor().Shutdown()
 			spec.wait(-1)
 		},
 	}))
@@ -379,7 +379,7 @@ func TestRetry(t *testing.T) {
 		OnReady: func(spec *Spec) {
 			count += 1
 			if count == N {
-				spec.process.Supervisor.Shutdown()
+				spec.process.Supervisor().Shutdown()
 			}
 		},
 	}))

--- a/pkg/supervisor/supervisor_test.go
+++ b/pkg/supervisor/supervisor_test.go
@@ -1,0 +1,318 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	UNSTARTED = 0
+	SETUP     = 1
+	READY     = 2
+	SHUTDOWN  = 3
+	CANCEL    = 4
+	EXITING   = 5
+)
+
+type Root map[string]*Spec
+
+type Spec struct {
+	Name       string
+	Error      string
+	Requires   []string
+	Retry      bool
+	OnStartup  func(*Spec)
+	OnReady    func(*Spec)
+	OnShutdown func(*Spec)
+	OnCancel   func(*Spec)
+	process    *Process
+	// holds the state of the worker
+	state  int
+	result error
+	// map of all the other workers
+	coworkers map[string]*Spec
+}
+
+func (spec *Spec) wait(timeout time.Duration) {
+	var timeoutChan <-chan time.Time
+	if timeout < 0 {
+		timeoutChan = make(chan time.Time)
+	} else {
+		timeoutChan = time.After(timeout)
+	}
+	p := spec.process
+	select {
+	case <-p.Shutdown():
+		spec.state = SHUTDOWN
+		p.Log("shutting down...")
+		if spec.OnShutdown != nil {
+			spec.OnShutdown(spec)
+		}
+		p.Log("shut down")
+	case <-p.Context.Done():
+		spec.state = CANCEL
+		p.Log("hard shutdown")
+		if spec.OnCancel != nil {
+			spec.OnCancel(spec)
+		}
+	case <-timeoutChan:
+		p.Log("shutting down spontaneously")
+	}
+}
+
+func (spec *Spec) assertRequiredReady() {
+	for _, r := range spec.Requires {
+		rs := spec.coworkers[r]
+		if rs.state != READY {
+			panic(fmt.Sprintf("%s is not ready", r))
+		}
+	}
+}
+
+func (r Root) worker(spec Spec) *Worker {
+	r[spec.Name] = &spec
+	spec.coworkers = r
+	return &Worker{
+		Name: spec.Name,
+		Work: func(p *Process) error {
+			spec.process = p
+			spec.state = SETUP
+			p.Log("setting up...")
+			if spec.OnStartup != nil {
+				spec.OnStartup(&spec)
+			}
+
+			spec.state = READY
+			p.Log("ready")
+			p.Ready()
+			if spec.OnReady != nil {
+				spec.OnReady(&spec)
+			}
+
+			spec.state = EXITING
+			if spec.Error == "" {
+				p.Log("exiting normally")
+			} else {
+				p.Logf("exiting with error: %s", spec.Error)
+				spec.result = fmt.Errorf(spec.Error)
+			}
+			return spec.result
+		},
+		Requires: spec.Requires,
+		Retry:    spec.Retry,
+	}
+}
+
+func newRoot() Root {
+	return make(map[string]*Spec)
+}
+
+func TestNormalExit(t *testing.T) {
+	r := newRoot()
+	s := WithContext(context.Background())
+	N := 3
+	counts := make([]int, N)
+	for i := 0; i < N; i++ {
+		num := i
+		s.Supervise(r.worker(Spec{
+			Name: fmt.Sprintf("minion-%d", num),
+			OnReady: func(spec *Spec) {
+				counts[num]++
+			},
+		}))
+	}
+	errors := s.Run()
+	for idx, count := range counts {
+		if count != 1 {
+			t.Errorf("minion %d failed to increment count", idx)
+		}
+	}
+	if len(errors) != 0 {
+		t.Errorf("unexpected errors: %v", errors)
+	}
+}
+
+func TestErrorExit(t *testing.T) {
+	r := newRoot()
+	s := WithContext(context.Background())
+	N := 3
+	counts := make([]int, N)
+	for i := 0; i < N; i++ {
+		num := i
+		s.Supervise(r.worker(Spec{
+			Name: fmt.Sprintf("minion-%d", num),
+			OnReady: func(spec *Spec) {
+				counts[num]++
+			},
+			Error: fmt.Sprintf("boo-%d", num),
+		}))
+	}
+	errors := s.Run()
+	for _, count := range counts {
+		if count != 1 {
+			t.Fail()
+		}
+	}
+	if len(errors) != N {
+		t.Fail()
+	}
+	for _, err := range errors {
+		if !strings.HasPrefix(err.Error(), "boo-") {
+			t.Fail()
+		}
+	}
+}
+
+func TestDependency(t *testing.T) {
+	r := newRoot()
+	s := WithContext(context.Background())
+	s.Supervise(r.worker(Spec{
+		Name: "minion",
+		OnShutdown: func(spec *Spec) {
+			if r["dependent-minion"].state != EXITING {
+				panic("dependent-minion has not exited")
+			}
+		},
+		OnReady: func(spec *Spec) { spec.wait(-1) },
+	}))
+	s.Supervise(r.worker(Spec{
+		Name:     "dependent-minion",
+		Requires: []string{"minion"},
+		OnReady: func(spec *Spec) {
+			if r["minion"].state != READY {
+				panic("minion not ready")
+			}
+			spec.process.Supervisor.Shutdown()
+		},
+	}))
+	errors := s.Run()
+	if len(errors) != 0 {
+		t.Errorf("unexpected errors: %v", errors)
+	}
+}
+
+func TestShutdownOnError(t *testing.T) {
+	r := newRoot()
+	s := WithContext(context.Background())
+	s.Supervise(r.worker(Spec{
+		Name:    "forever",
+		OnReady: func(spec *Spec) { spec.wait(-1) },
+	}))
+	s.Supervise(r.worker(Spec{
+		Name:  "buggy",
+		Error: "bug",
+	}))
+	errors := s.Run()
+	if len(errors) != 1 && errors[0].Error() != "bug" {
+		t.Errorf("unexpected errors: %v", errors)
+	}
+}
+
+func TestShutdown(t *testing.T) {
+	r := newRoot()
+	s := WithContext(context.Background())
+	s.Supervise(r.worker(Spec{
+		Name:    "forever",
+		OnReady: func(spec *Spec) { spec.wait(-1) },
+	}))
+	s.Supervise(r.worker(Spec{
+		Name: "quitter",
+		OnReady: func(spec *Spec) {
+			spec.process.Supervisor.Shutdown()
+			spec.wait(-1)
+		},
+	}))
+	errors := s.Run()
+	if len(errors) != 0 {
+		t.Errorf("unexpected errors: %v", errors)
+	}
+}
+
+// This test is probably written to be more specific than it
+// necessarily needs to be... it's actually checking that we run the
+// worker and then cancel, whereas if cancel happens prior to Run()
+// being called, I'm guessing we might want to turn Run into a noop.
+func TestCancelPreRun(t *testing.T) {
+	r := newRoot()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	s := WithContext(ctx)
+	ran := false
+	s.Supervise(r.worker(Spec{
+		Name: "forever",
+		OnReady: func(spec *Spec) {
+			ran = true
+			spec.wait(-1)
+		},
+	}))
+	errors := s.Run()
+	if len(errors) != 0 {
+		t.Errorf("unexpected errors: %v", errors)
+	}
+	if !ran {
+		t.Fail()
+	}
+}
+
+func TestCancelPostRun(t *testing.T) {
+	r := newRoot()
+	ctx, cancel := context.WithCancel(context.Background())
+	s := WithContext(ctx)
+	ran := false
+	s.Supervise(r.worker(Spec{
+		Name: "forever",
+		OnStartup: func(spec *Spec) {
+			ran = true
+		},
+		OnReady: func(spec *Spec) {
+			spec.wait(-1)
+		},
+	}))
+	s.Supervise(r.worker(Spec{
+		Name:     "canceller",
+		Requires: []string{"forever"},
+		OnReady: func(spec *Spec) {
+			if !ran {
+				t.Fail()
+			}
+			cancel()
+			spec.wait(-1)
+		},
+	}))
+
+	errors := s.Run()
+	if len(errors) != 0 {
+		t.Errorf("unexpected errors: %v", errors)
+	}
+	if !ran {
+		t.Fail()
+	}
+}
+
+func TestRetry(t *testing.T) {
+	r := newRoot()
+	s := WithContext(context.Background())
+	N := 3
+	count := 0
+	s.Supervise(r.worker(Spec{
+		Name:  "buggy",
+		Error: "oops",
+		Retry: true,
+		OnReady: func(spec *Spec) {
+			count += 1
+			if count == N {
+				spec.process.Supervisor.Shutdown()
+			}
+		},
+	}))
+	errors := s.Run()
+	if len(errors) != 0 {
+		t.Errorf("unexpected errors: %v", errors)
+	}
+	if count != N {
+		t.Errorf("unexpected count: %d", count)
+	}
+}


### PR DESCRIPTION
This work is motivated by a number of separate but related problems we have run into over the course of developing teleproxy, apictl, and kubewatch.

1. Much of the structure of what teleproxy does is to manage distinct goroutines and/or subprocesses in such a way as to maintain connectivity, routing, and dns. Off the top of my head it manages a set of intercepts using the local firewall, an in-process dns server, an in-process routing table, an in-process api server for accessing/modifying said routing table, a kubernetes bridge, a docker bridge, a kubectl port-forward, an ssh port-forward, and a partridge in a pear tree. None of these are super complicated in and of themselves, however they all have various dependency relationships between them and there are some hard cleanup requirements as well (e.g. never leave the firewall in a bad state).

   The way this is currently written spaghetties a lot of this concurrency/cleanup/retry logic around the code, so it's really kinda hard to follow/reason about. The hope is that this supervisor abstraction will allow the code, the dependencies, and the cleanup logic to be expressed in a much clearer way.

2. Teleproxy currently only handles outbound stuff. As we have developed apictl more, it has become clear that we will need a daemon process to manage inbound as well, and this will likely either make the teleproxy concurrency situation worse if we extend it to handle inbound, or introduce another program with similar properties.

3. With kubewatch getting extended to interact with consul in addition to kubernetes, it seems likely we will be creating yet another long running go process that has different moving sub parts (the part that watches kubernetes, the part that watches consul, and the part that assembles/supervises ambassador reconfigs).

So all in all it seems like an abstraction to centralize and simplify how we do this sort of thing seems useful. I think the ultimate goal and true test of this abstraction would be whether we can use this to cleanly define the different workers within a long-running program... e.g. what dependencies each worker has, what it's retry policy is, and then just write a bunch of straightforward business logic to implement each worker itself.