### PR TITLE
Support KUBEWATCH_LABEL_SELECTOR to only process objects with a given selector.

### DIFF
--- a/pkg/k8s/watcher.go
+++ b/pkg/k8s/watcher.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -23,12 +24,22 @@ type listWatchAdapter struct {
 }
 
 func (lw listWatchAdapter) List(options v1.ListOptions) (runtime.Object, error) {
+	// support additional label selectors to reduce the number of objects processed
+	labelSelector := os.Getenv("KUBEWATCH_LABEL_SELECTOR")
+	if labelSelector != "" && options.LabelSelector == "" {
+		options.LabelSelector = labelSelector
+	}
 	// silently coerce the returned *unstructured.UnstructuredList
 	// struct to a runtime.Object interface.
 	return lw.resource.List(options)
 }
 
 func (lw listWatchAdapter) Watch(options v1.ListOptions) (pwatch.Interface, error) {
+	// support additional label selectors to reduce the number of objects processed
+	labelSelector := os.Getenv("KUBEWATCH_LABEL_SELECTOR")
+	if labelSelector != "" && options.LabelSelector == "" {
+		options.LabelSelector = labelSelector
+	}
 	return lw.resource.Watch(options)
 }
 


### PR DESCRIPTION
This allows an operator to reduce the number of objects processed when they know that only a subset actually matter.

This particular implementation is simple and works, though a bit lazy. Let me know if there's a better way to do this.

Related: https://github.com/datawire/ambassador/issues/1292