### PR TITLE
Fix docker inspect and command formatting

### DIFF
--- a/internal/pkg/docker/watch.go
+++ b/internal/pkg/docker/watch.go
@@ -76,11 +76,9 @@ func (w *Watcher) containers() (result map[string]string, err error) {
 		return
 	}
 
-	ids = strings.Join(strings.Fields(ids), " ")
-
 	lines := ""
 	if ids != "" {
-		lines, err = tpu.CmdLogf(append([]string{"docker", "inspect", "--format={{.Name}} {{.NetworkSettings.IPAddress}}", "--"}, ids), w.log)
+		lines, err = tpu.CmdLogf(append([]string{"docker", "inspect", "--format={{.Name}} {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}", "--"}, strings.Fields(ids)...), w.log)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
This commit fixes 2 things -
1. docker command for inspecting a container was using an older
   version of formatter which does not work anymore.
2. container IDs being passed to the `docker inspect` command were
   being passed as a single string, which makes `docker inspect`
   fail. It's now unfurled from a slice of strings.