### PR TITLE
interpolate environment variable data into address field

### DIFF
--- a/cmd/watt/consulwatchman.go
+++ b/cmd/watt/consulwatchman.go
@@ -28,6 +28,7 @@ type ConsulWatchMaker struct {
 
 func (m *ConsulWatchMaker) MakeConsulWatch(spec ConsulWatchSpec) (*supervisor.Worker, error) {
 	consulConfig := consulapi.DefaultConfig()
+	spec.ConsulAddress = os.ExpandEnv(spec.ConsulAddress)
 	consulConfig.Address = spec.ConsulAddress
 
 	// TODO: Should we really allocated a Consul client per Service watch? Not sure... there some design stuff here
@@ -74,7 +75,6 @@ func (m *ConsulWatchMaker) MakeConsulWatch(spec ConsulWatchSpec) (*supervisor.Wo
 
 func (w *consulwatchman) Work(p *supervisor.Process) error {
 	p.Ready()
-
 	for {
 		select {
 		case watches := <-w.watchesCh:


### PR DESCRIPTION
This PR makes it so the `address` field in a Consul Resolver can have an environment variable substitution in it. For example, you can write

`address: "${HOST_IP}"` and if the `HOST_IP` environment variable is set then it will be replaced with the value. When deploying `watt` something like this might be used:

```
containers:
        - name: example
          image: "watt`
          env:
            - name: HOST_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.hostIP
```

I think there is some UX stuff to talk around here...