### PR TITLE
Embed Teleproxy into Edge Control

### DIFF
--- a/cmd/edgectl/cluster.go
+++ b/cmd/edgectl/cluster.go
@@ -41,13 +41,10 @@ func (d *Daemon) Connect(p *supervisor.Process, out *Emitter, rai *RunAsInfo, ka
 	}
 	d.cluster = cluster
 
-	if err := d.FindTeleproxy(); err != nil {
-		return err
-	}
 	bridge, err := CheckedRetryingCommand(
 		p,
 		"bridge",
-		[]string{d.teleproxy, "--mode", "bridge"},
+		[]string{edgectl, "teleproxy", "bridge"},
 		rai,
 		checkBridge,
 		15*time.Second,

--- a/cmd/edgectl/daemon.go
+++ b/cmd/edgectl/daemon.go
@@ -13,8 +13,6 @@ import (
 
 // Daemon represents the state of the Edge Control Daemon
 type Daemon struct {
-	teleproxy string
-
 	network        Resource
 	cluster        *KCluster
 	bridge         Resource

--- a/cmd/edgectl/teleproxy.go
+++ b/cmd/edgectl/teleproxy.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os"
+
+	"github.com/datawire/teleproxy/pkg/teleproxy"
+	"github.com/pkg/errors"
+)
+
+// RunAsTeleproxyIntercept is the main function when executing as
+// teleproxy intercept
+func RunAsTeleproxyIntercept() error {
+	if os.Geteuid() != 0 {
+		return errors.New("edgectl daemon as teleproxy intercept must run as root")
+	}
+	tele := teleproxy.Teleproxy{Mode: "intercept"}
+	return teleproxy.RunTeleproxy(tele, displayVersion)
+}
+
+// RunAsTeleproxyBridge is the main function when executing as
+// teleproxy bridge
+func RunAsTeleproxyBridge() error {
+	tele := teleproxy.Teleproxy{Mode: "bridge"}
+	return teleproxy.RunTeleproxy(tele, displayVersion)
+}


### PR DESCRIPTION
... thereby avoiding Edge Control having a dependency on a Teleproxy executable.