### PR TITLE
Fix teleproxy for my home WiFi+k3sctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ include build-aux/go-mod.mk
 include build-aux/go-version.mk
 include build-aux/help.mk
 
+build-aux/go-test.tap: vendor
+
 # Utility targets
 
 release: ## Upload binaries to S3

--- a/internal/pkg/dns/dns.go
+++ b/internal/pkg/dns/dns.go
@@ -1,5 +1,4 @@
 package dns
-
 import (
 	_log "log"
 	"net"
@@ -25,7 +24,19 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	domain := strings.ToLower(r.Question[0].Name)
 	switch r.Question[0].Qtype {
 	case dns.TypeA:
-		ip := s.Resolve(domain)
+		var ip string
+		if domain == "localhost." {
+			// BUG(lukeshu): I have no idea why a lookup
+			// for localhost even makes it to here on my
+			// home WiFi when connecting to a k3sctl
+			// cluster (but not a kubernaut.io cluster).
+			// But it does, so I need this in order to be
+			// productive at home.  We should really
+			// root-cause this, because it's weird.
+			ip = "127.0.0.1"
+		} else {
+			ip = s.Resolve(domain)
+		}
 		if ip != "" {
 			log("QUERY %s -> %s", domain, ip)
 			msg := dns.Msg{}


### PR DESCRIPTION
 1. Restore having the Makefile run `go mod vendor` before running the tests.
 2. Add a workaround for k3sctl+my home WiFi.