### PR TITLE
.circleci: Upgrade Go 1.12.5 → 1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ commands:
       # pipe the curl straight to tar.
       - run: |
           sudo rm -rf /usr/local/go &&
-          curl https://dl.google.com/go/go1.12.5.<<parameters.os>>-amd64.tar.gz -o /tmp/go.tgz &&
+          curl https://dl.google.com/go/go1.13.<<parameters.os>>-amd64.tar.gz -o /tmp/go.tgz &&
           sudo tar -C /usr/local -xzf /tmp/go.tgz
 
       # Golang paths


### PR DESCRIPTION
This should resolve CI errors about the git.apache.org outage, as 1.13
uses `GOPROXY=https://proxy.golang.org,direct` by default, and
proxy.golang.org should have the apache stuff cached.

This does NOT include any other improvements that go with 1.13, like teaching build-aux how to build things faster.  That's in the works, though.