### PR TITLE
Fix blocking channel writes

### DIFF
--- a/cmd/watt/aggregator.go
+++ b/cmd/watt/aggregator.go
@@ -177,8 +177,20 @@ func (a *aggregator) notify(p *supervisor.Process) {
 
 	p.Logf("found %d kubernetes watches", len(watchset.KubernetesWatches))
 	p.Logf("found %d consul watches", len(watchset.ConsulWatches))
-	a.k8sWatches <- watchset.KubernetesWatches
-	a.consulWatches <- watchset.ConsulWatches
+
+	select {
+	case a.k8sWatches <- watchset.KubernetesWatches:
+		p.Logf("notified Kubernetes watch")
+	default:
+		p.Logf("Kubernetes watch not notified")
+	}
+
+	select {
+	case a.consulWatches <- watchset.ConsulWatches:
+		p.Logf("notified Consul watch")
+	default:
+		p.Logf("Consul watch not notified")
+	}
 
 	if !a.bootstrapped && a.isComplete(p, watchset) {
 		p.Logf("bootstrapped!")


### PR DESCRIPTION
Upon consecutive additions and deletions, without delay, to watched
resources, after a while, by the time a Kubernetes watch is sent
to aggregator.k8sWatch, it no longer exists hence creating a
blocking channel which halts the entire execution leading to
no further updates and rendering watt stuck forever. This commit
makes that blocking write non-blocking.