### PR TITLE
.github/pull_request_template.md: Add a checkbox reminding you to upd…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Description
+
+A few sentences describing the overall goals of the pull request's commits.
+
+## Checklist
+
+ - [ ] I made sure to update `CHANGELOG.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ kubestatus, and the various libraries that they use.  Lines within
 each entry are prefixed with <b>[`<name>`]</b> to indicate what they
 refer to.
 
+## 0.7.3 (TBD)
+
+ * The `go.mod` dependency list should now be less problematic; upgrade consul 1.4.4→1.5.0.
+ * <b>[edgectl]</b> Better output.
+ * <b>[edgectl]</b> `su`/`sudo` bug fixed.
+ * <b>[k3sctl]</b> Bug fix: More robust readiness check.
+ * <b>[teleproxy]</b> Once again works properly for services with multiple ports.
+ * <b>[lib/dlog]</b> Added.
+ * <b>[lib/dtest/testprocess]</b> Enhancement: Don't require the use of `sudo`.
+ * <b>[lib/exec]</b> Added.
+ * <b>[lib/k8s]</b> BREAKING CHANGE: Many things moved to <b>[lib/kubeapply]</b>.
+ * <b>[lib/kubeapply]</b> Added.
+
 ## 0.7.2 (2019-08-21)
 
  * <b>[kubestatus]</b> Bug fix: kubestatus will work properly on non namespaced resources.

--- a/pkg/dexec/cmd.go
+++ b/pkg/dexec/cmd.go
@@ -129,7 +129,6 @@ func (c *Cmd) Start() error {
 	}
 
 	err := c.Cmd.Start()
-	c.pidlock.Unlock()
 	if err == nil {
 		c.logger.Printf("[pid:%v] started command %#v", c.Process.Pid, c.Args)
 		if stdin, isFile := c.Stdin.(*os.File); isFile {
@@ -142,6 +141,7 @@ func (c *Cmd) Start() error {
 			c.logger.Printf("[pid:%v] stderr > not logging output written to file %s", c.Process.Pid, stderr.Name())
 		}
 	}
+	c.pidlock.Unlock()
 	return err
 }
 


### PR DESCRIPTION
…ate CHANGELOG

The intent has been that CHANGELOG.md be continually up-to-date, so that
when we want to cut a release, all that needs to happen in CHANGELOG.md
is to set the release date.

But that hasn't been happening; PRs that change things haven't touched
CHANGELOG.md.  Because of this, yesterday (2019-09-19), both Abhay and I
agreed that we should do a release, but neither of us really wanted to
interrupt what we were doing to go through the git log to see what
changed.

I noted that in apro.git, adding a checkbox to the PR template reminding
you to update the CHANGELOG in your PR has been super-helpful in making
sure that the CHANGELOG is always up-to-date.  We agreed that adding the
same thing to teleproxy.git would be a good idea.