### PR TITLE
Make KubernetesWatchMaker.notify buffered

### DIFF
--- a/cmd/watt/kubewatchman.go
+++ b/cmd/watt/kubewatchman.go
@@ -22,6 +22,8 @@ func (m *KubernetesWatchMaker) MakeKubernetesWatch(spec KubernetesWatchSpec) (*s
 	var worker *supervisor.Worker
 	var err error
 
+	m.notify = make(chan<- k8sEvent, 1)
+
 	worker = &supervisor.Worker{
 		Name: fmt.Sprintf("kubernetes:%s", spec.WatchId()),
 		Work: func(p *supervisor.Process) error {


### PR DESCRIPTION
This commit makes KubernetesWatchMaker.notify a buffered channel
of size 1 instead of an unbuffered channel. Prior to this commit,
KubernetesWatchMaker.notify would block in case of rapid changes
to a given resource in a cluster - this fix avoids that.