### PR TITLE
.circleci: Try to make the file a little more manageable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,43 +1,75 @@
 version: 2.1
 
 commands:
-  aws-install:
-    steps:
-      - run: |
-          sudo pip install awscli
 
-  golang-install:
+  "brew-install":
     parameters:
-      os:
+      "packages":
         type: string
     steps:
-      # Golang install
+      - restore_cache:
+          name: "Restore brew cache"
+          keys:
+            - brew-{{ arch }}
+      - run: brew install << parameters.packages >>
+      - save_cache:
+          name: "Save brew cache"
+          key: brew-{{ arch }}
+          paths:
+            - "/usr/local/Homebrew"
 
-      # For some reason it is faster to curl into a file than to just
-      # pipe the curl straight to tar.
-      - run: |
-          sudo rm -rf /usr/local/go &&
-          curl https://dl.google.com/go/go1.13.<<parameters.os>>-amd64.tar.gz -o /tmp/go.tgz &&
-          sudo tar -C /usr/local -xzf /tmp/go.tgz
-
-      # Golang paths
-      - run: |
-          echo 'export PATH=${PATH}:/usr/local/go/bin' >> ${BASH_ENV} &&
-          echo 'export GOPATH=${HOME}/go' >> ${BASH_ENV}
-
-      - run: 'echo PATH: ${PATH} || true'
-      - run: 'echo GOPATH: ${GOPATH} || true'
-      - run: go version
-
-  kubectl-install:
+  "pip-install":
+    parameters:
+      "packages":
+        type: string
     steps:
-      - run: curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.12.2/bin/$(go env GOOS)/$(go env GOARCH)/kubectl
-      - run: chmod a+x ./kubectl
-      - run: sudo mv kubectl /usr/local/bin
+      - run: sudo pip install << parameters.packages >>
 
-  save-go-mod-cache:
+  "install-go":
+    parameters:
+      "version":
+        type: string
+        default: "1.13"
     steps:
       - run:
+          name: "Install Go << parameters.version >>"
+          command: |
+            curl -L --fail -o /tmp/go.tar.gz https://dl.google.com/go/go<< parameters.version >>.$(uname -s | tr A-Z a-z)-amd64.tar.gz
+            tar -C /tmp -xzf /tmp/go.tar.gz
+            echo 'export PATH=/tmp/go/bin:$PATH' >> "$BASH_ENV"
+            if [ -z "$(/tmp/go/bin/go env GOPROXY)" ]; then
+              echo 'export GOPROXY=https://proxy.golang.org' >> "$BASH_ENV"
+            fi
+
+  "install-kubectl":
+    parameters:
+      "version":
+        type: string
+        default: "1.12.2"
+    steps:
+      - run:
+          name: "Install kubectl << parameters.version >>"
+          command: |
+            curl -L --fail -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v<< parameters.version >>/bin/$(uname -s | tr A-Z a-z)/amd64/kubectl
+            sudo install /tmp/kubectl /usr/local/bin/kubectl
+
+  "with-go-mod-cache":
+    parameters:
+      "steps":
+        type: steps
+    steps:
+      - restore_cache:
+          name: "Restore Go module cache"
+          keys:
+            - go-mod-cache-{{ arch }}-{{ checksum "go.mod" }}-
+            - go-mod-cache-{{ arch }}-
+      - run: |
+          echo 'export GOPROXY=file://$HOME/goproxy,$(go env GOPROXY)' >> "${BASH_ENV}"
+
+      - steps: << parameters.steps >>
+
+      - run:
+          name: "Prepare to save Go module cache"
           command: |
             mkdir -p "$(go env GOPATH)/pkg/mod/cache/download/"
             rsync -av --delete "$(go env GOPATH)/pkg/mod/cache/download/" ~/goproxy
@@ -51,32 +83,72 @@ commands:
           # able to share the cache?  Because /tmp is a symlink to
           # /private/tmp on macOS, and CircleCI is broken on macOS
           # whenever symlinks are involved.
+          name: "Save Go module cache"
           key: go-mod-cache-{{ arch }}-{{ checksum "go.mod" }}-{{ .BuildNum }}
           paths: "~/goproxy"
           when: always
-  restore-go-mod-cache:
+
+  "with-docker-machine":
+    parameters:
+      "steps":
+        type: steps
     steps:
       - restore_cache:
+          name: "Restore docker-machine cache"
           keys:
-            - go-mod-cache-{{ arch }}-{{ checksum "go.mod" }}-
-            - go-mod-cache-{{ arch }}-
-      - run: |
-          echo 'export GOPROXY=file://$HOME/goproxy,$(go env GOPROXY)' >> "${BASH_ENV}"
+            - docker-machine-{{ arch }}
+      - run:
+          name: "Launch docker-machine"
+          command: |
+            docker-machine create default --xhyve-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v19.03.2/boot2docker.iso --driver xhyve
+            # docker-machine backgrounded itself, but because Circle
+            # CI will kill the process group if the 'command' returns,
+            # so we now sleep forever.
+            while true; do sleep 7200; done
+          background: true
+      - run:
+          name: Wait for docker-machine to become ready
+          command: until docker-machine env; do sleep 3; done && docker-machine env >> ${BASH_ENV}
+      - run: docker system info
 
-  main:
+      - steps: << parameters.steps >>
+
+      - save_cache:
+          name: "Save docker-machine cache"
+          key: docker-machine-{{ arch }}
+          paths: "~/.docker"
+
+  "docker-machine-port-forward":
+    parameters:
+      "port-name":
+        type: string
+        default: "UNDEFINED"
+      "port-number":
+        type: integer
+        default: 1
+    steps:
+      - run:
+          name: "docker-machine port-forward: << parameters.port-name >> (IPv4)"
+          command: "socat tcp4-listen:<< parameters.port-number >>,reuseaddr,fork tcp:$(docker-machine ip):<< parameters.port-number >>"
+          background: true
+      - run:
+          name: "docker-machine port-forward: << parameters.port-name >> (IPv6)"
+          command: "socat tcp6-listen:<< parameters.port-number >>,reuseaddr,fork tcp:$(docker-machine ip):<< parameters.port-number >>"
+          background: true
+
+  "main":
     steps:
       - checkout
-      - restore-go-mod-cache
-      - run: go mod vendor
+      - with-go-mod-cache:
+          steps:
+            - run: make build
+            - run:
+                # Use a ridiculously-long timeout because macOS CI is slow and
+                # teleproxy/edgectl tests serialize on the machine lock.
+                command: GOFLAGS=-timeout=30m make check
+                no_output_timeout: 30m
       - run:
-          # Use a ridiculously-long timeout because MacOS CI is slow and
-          # teleproxy/edgectl tests serialize on the machine lock.
-          command: GOFLAGS=-timeout=30m make check
-          no_output_timeout: 30m
-      - save-go-mod-cache
-      - run: make build
-      - run:
-          name: "gather logs"
+          name: "Gather logs"
           when: always
           command: |
             cp /tmp/edgectl.log . || true
@@ -94,73 +166,48 @@ commands:
 
 jobs:
 
-  macos-build:
+  "macOS":
     macos:
+      # macOS 10.12 (Sierra)
       xcode: "9.0"
-    working_directory: ~/repo
     steps:
-      - restore_cache:
-          keys:
-            - brew-cache-2
-      - run: brew install socat docker-machine-driver-xhyve docker &&
-             sudo chown root:wheel /usr/local/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve &&
-             sudo chmod u+s /usr/local/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
-      - run:
-          name: Docker Virtual Machine
-          command: docker-machine create default --xhyve-boot2docker-url https://github.com/boot2docker/boot2docker/releases/download/v19.03.2/boot2docker.iso --driver xhyve && sleep 7200
-          background: true
-      - run: until docker-machine env; do sleep 3; done && docker-machine env >> ${BASH_ENV}
-      - run: docker system info
-      - save_cache:
-          key: brew-cache-2
-          paths:
-            - /usr/local/Homebrew
-            - ".docker"
-          when: always
-      - run:
-          name: Registry Port Forward (IPv4)
-          command: socat tcp4-listen:5000,reuseaddr,fork tcp:$(docker-machine ip):5000
-          background: true
-      - run:
-          name: K3s Port Forward (IPv4)
-          command: socat tcp4-listen:6443,reuseaddr,fork tcp:$(docker-machine ip):6443
-          background: true
-      - run:
-          name: Registry Port Forward (IPv6)
-          command: socat tcp6-listen:5000,reuseaddr,fork tcp:$(docker-machine ip):5000
-          background: true
-      - run:
-          name: K3s Port Forward (IPv6)
-          command: socat tcp6-listen:6443,reuseaddr,fork tcp:$(docker-machine ip):6443
-          background: true
-      - aws-install
-      - golang-install:
-          os: darwin
-      - kubectl-install
-      - run: brew install jq
-      - main
+      - brew-install:
+          packages: socat docker-machine-driver-xhyve docker jq
+      - run: |
+          sudo chown root:wheel /usr/local/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve &&
+          sudo chmod u+s /usr/local/opt/docker-machine-driver-xhyve/bin/docker-machine-driver-xhyve
+      - pip-install:
+          packages: awscli
+      - install-go
+      - install-kubectl
+      - with-docker-machine:
+          steps:
+            - docker-machine-port-forward:
+                port-name: "Docker Registry"
+                port-number: 5000
+            - docker-machine-port-forward:
+                port-name: "k3s"
+                port-number: 6443
+            - main
 
-  machine-build:
+  "Ubuntu":
     machine:
       image: "ubuntu-1604:201903-01"
-    working_directory: ~/repo
     steps:
-      - aws-install
-      - golang-install:
-          os: linux
-      - kubectl-install
+      - pip-install:
+          packages: awscli
+      - install-go
+      - install-kubectl
       - main
 
 workflows:
-  version: 2.1
-
-  multibuild:
+  "ETK CI":
     jobs:
-      - machine-build:
+      - "macOS":
           filters:
             tags:
               only: /.*/
-      - macos-build:
+      - "Ubuntu":
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
## Description

Remember how when reviewing the docker-machine work, I commented that it was a little messy, and it would be good to factor it a bit to make it more easily usable elsewhere? This is that.

Use a buncha snippets and techniques from build-aux.git and apro.git to clean up the `.circleci` config.

Also this cut the macOS job down from 20 minutes to 14 minutes.  I didn't actually intend to do that, and haven't looked in to where the improvement is coming from.

Oh, this renames the jobs from "machine-build" and "macos-build" to "Ubuntu" and "macOS".  We'll need to edit the GitHub branch protection before merging.

## Checklist

 - [x] I made sure to update `CHANGELOG.md` - no applicable changes
