### PR TITLE
Allow kubeapply --filename in addition to -f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ refer to.
  * <b>[edgectl]</b> Better output.
  * <b>[edgectl]</b> `su`/`sudo` bug fixed.
  * <b>[k3sctl]</b> Bug fix: More robust readiness check.
+ * <b>[kubeapply]</b> Accept `--filename` in addition to `-f`, just like `kubectl apply`.
  * <b>[teleproxy]</b> Once again works properly for services with multiple ports.
  * <b>[lib/dlog]</b> Added.
  * <b>[lib/dtest/testprocess]</b> Enhancement: Don't require the use of `sudo`.

--- a/cmd/kubeapply/main.go
+++ b/cmd/kubeapply/main.go
@@ -38,7 +38,7 @@ func main() {
 	timeout := ka.Flags().DurationP("timeout", "t", time.Minute,
 		"timeout to wait for each applied YAML phase to become ready")
 	showVersion := ka.Flags().Bool("version", false, "output version information and exit")
-	files := ka.Flags().StringArrayP("", "f", nil, "files to apply")
+	files := ka.Flags().StringSliceP("filename", "f", nil, "files to apply")
 
 	ka.RunE = func(cmd *cobra.Command, args []string) error {
 		if *showVersion {


### PR DESCRIPTION
## Description

Allow `--filename` in addition to `-f`, just as `kubectl apply` does.

## Checklist

 - [x] I made sure to update `CHANGELOG.md`
