### PR TITLE
Make Kubernetes and Consul watch channels buffered

### DIFF
--- a/cmd/watt/main.go
+++ b/cmd/watt/main.go
@@ -80,11 +80,11 @@ func _runWatt(cmd *cobra.Command, args []string) int {
 
 	// The aggregator sends the current consul resolver set to the
 	// consul watch manager.
-	aggregatorToConsulwatchmanCh := make(chan []ConsulWatchSpec)
+	aggregatorToConsulwatchmanCh := make(chan []ConsulWatchSpec, 100)
 
 	// The aggregator sends the current k8s watch set to the
 	// kubernetes watch manager.
-	aggregatorToKubewatchmanCh := make(chan []KubernetesWatchSpec)
+	aggregatorToKubewatchmanCh := make(chan []KubernetesWatchSpec, 100)
 
 	invoker := NewInvoker(port, notifyReceivers)
 	limiter := limiter.NewComposite(limiter.NewUnlimited(), limiter.NewInterval(interval), interval)


### PR DESCRIPTION
Co-authored-by: Rafael Schloming <rhs@datawire.io>
Co-authored-by: Flynn <flynn@datawire.io>

In case of rapid additions and deletions of the same resource
makes watt become unresponsive. This broadly happens because watt
creates and deletes watches of the same name in rapid succession,
and after some time watt reaches a place where a watcher is trying
to shut down but it blocks on an aggregator notify event.

This commit makes watch channels buffered which gives the code
enough leeway to process rapid changes to the cluster.